### PR TITLE
Update to allow for blank titles

### DIFF
--- a/app/assets/javascripts/billboard/billboard.js
+++ b/app/assets/javascripts/billboard/billboard.js
@@ -43,8 +43,11 @@ function renderSlide(slide){
 }
 
 function assemble(slide) {
-  var slideHTML = "<h1 class='billboard-title'>" + slide.title + "</h1>" +
-    "<h2 class='billboard-message'>" + slide.message + "</h1>" +
-    "<img src='" + slide.image_url + "' class='billboard-image'>";
+  var slideHTML = "";
+    if (slide.title != "") {
+      slideHTML += "<h1 class='billboard-title'>" + slide.title + "</h1>" +
+      "<h2 class='billboard-message'>" + slide.message + "</h2>";
+    }
+    slideHTML += "<img src='" + slide.image_url + "' class='billboard-image'>";
   return slideHTML;
 }

--- a/app/controllers/admin/slides_controller.rb
+++ b/app/controllers/admin/slides_controller.rb
@@ -16,8 +16,8 @@ class Admin::SlidesController < Admin::BaseController
   def create
     @slide = Slide.new(slide_params)
     @slide.user = current_user
-    @slide.approved!
     if @slide.save
+      @slide.approved!
       flash[:success] = "Slide successfully created"
       redirect_to admin_slide_path(@slide)
     else
@@ -58,7 +58,7 @@ class Admin::SlidesController < Admin::BaseController
 
   private
   def slide_params
-    params.permit(:title, :message, :image_url, :expiration_date, :image, :status)
+    params.require(:slide).permit(:title, :message, :image_url, :expiration_date, :image, :status)
   end
 
   def fourteen_days

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -10,4 +10,12 @@ class Slide < ApplicationRecord
   def image_url
     image.url
   end
+
+  def title_with_blanks
+    if title == ""
+      "No title"
+    else
+      title
+    end
+  end
 end

--- a/app/views/admin/slides/index.html.erb
+++ b/app/views/admin/slides/index.html.erb
@@ -3,10 +3,10 @@
 
   <% @slides.each do |slide| %>
     <p>
-      <%= link_to slide.title, admin_slide_path(slide) %>
+      <%= link_to slide.title_with_blanks, admin_slide_path(slide) %>
       <%= button_to "Delete Slide", admin_slide_path(slide), method: :delete %>
       <%= button_to "Edit Slide", edit_admin_slide_path(slide), method: :get %>
-      <%= button_to "Approve Slide", admin_slide_path(slide, {status: :approved}), method: :patch %>
+      <%= button_to "Approve Slide", admin_slide_path(slide, {slide: {status: :approved}}), method: :patch %>
     </p>
   <% end %>
 </div>

--- a/app/views/admin/slides/new.html.erb
+++ b/app/views/admin/slides/new.html.erb
@@ -2,5 +2,13 @@
   <h1>Create New Slide</h1>
 
   <%= render "form" %>
+
+  <p>Tips</p>
+  <ul>
+    <li>Creating a slide with no title will display only the image you provide</li>
+    <li>Images are pinned to the top of the frame and expanded to be as wide as the viewport</li>
+    <li>To ensure that your slide fills the viewport, make them slightly taller than necessary</li>
+    <li>Do not put critical information at the bottom of an image as it may be cut off or covered by the Title and Message</li>
+  </ul>
 </div>
 

--- a/app/views/admin/slides/show.html.erb
+++ b/app/views/admin/slides/show.html.erb
@@ -1,8 +1,10 @@
 <div class="app-body">
   <%= link_to "Edit Slide", edit_admin_slide_path(@slide) %>
   <%= link_to "Delete Slide", admin_slide_path(@slide), method: :delete %>
-  <%= link_to "Approve Slide", admin_slide_path(@slide, {status: :approved}), method: :patch %>
+  <%= link_to "Approve Slide", admin_slide_path(@slide, {slide: {status: :approved}}), method: :patch %>
 </div>
-<h1 class='billboard-title'><%= @slide.title %></h1>
-<h2 class='billboard-message'><%= @slide.message %></h2>
+<% if @slide.title != "" %>
+  <h1 class='billboard-title'><%= @slide.title %></h1>
+  <h2 class='billboard-message'><%= @slide.message %></h2>
+<% end %>
 <img src="<%= @slide.image_url %>" class='billboard-image'>

--- a/app/views/slides/index.html.erb
+++ b/app/views/slides/index.html.erb
@@ -2,7 +2,7 @@
   <h1>All Slides</h1>
   <% @slides.each do |slide| %>
 
-    <p><%= link_to slide.title, slide_path(slide) %> <%= button_to "Edit Slide", edit_slide_path(slide), method: :get %> <%= button_to "Delete Slide", slide_path(slide), method: :delete %></p>
+    <p><%= link_to slide.title_with_blanks, slide_path(slide) %> <%= button_to "Edit Slide", edit_slide_path(slide), method: :get %> <%= button_to "Delete Slide", slide_path(slide), method: :delete %></p>
 
   <% end %>
 </div>

--- a/app/views/slides/new.html.erb
+++ b/app/views/slides/new.html.erb
@@ -2,5 +2,13 @@
   <h1>Create New Slide</h1>
 
   <%= render "form" %>
+
+  <p>Tips</p>
+  <ul>
+    <li>Creating a slide with no title will display only the image you provide</li>
+    <li>Images are pinned to the top of the frame and expanded to be as wide as the viewport</li>
+    <li>To ensure that your slide fills the viewport, make them slightly taller than necessary</li>
+    <li>Do not put critical information at the bottom of an image as it may be cut off or covered by the Title and Message</li>
+  </ul>
 </div>
 

--- a/app/views/slides/show.html.erb
+++ b/app/views/slides/show.html.erb
@@ -6,6 +6,8 @@
   <p>Current Status: <%= @slide.status.capitalize %></p>
   <p>Slides will be displayed once approved.</p>
 </div>
-<h1 class='billboard-title'><%= @slide.title %></h1>
-<h2 class='billboard-message'><%= @slide.message %></h2>
+<% if @slide.title != "" %>
+  <h1 class='billboard-title'><%= @slide.title %></h1>
+  <h2 class='billboard-message'><%= @slide.message %></h2>
+<% end %>
 <img src="<%= @slide.image_url %>" class='billboard-image'>


### PR DESCRIPTION
* Change `billboard` display to not show title or message bar if they are blank.
* Adjust `show` for default and admin to not show title or message bar if they are blank.
* Create a `title_with_blanks` method to display "No Title" on the index when a title is blank.
* Add tips to `new` views to give users ideas of how to create slides with blank titles and other tips.
* Fix `Admin::SlidesController` to only change the status of a slide if it successfully saves.